### PR TITLE
#166105280: Admin delete an ad

### DIFF
--- a/server/controllers/CarController.js
+++ b/server/controllers/CarController.js
@@ -180,6 +180,34 @@ const Car = {
     });
   },
 
+  deleteAd(req, res) {
+    if (!req.params.id) {
+      return res.status(400).send({
+        status: 400,
+        message: 'Invalid request',
+      });
+    }
+
+    const car = CarModel.findSingle(req.params.id);
+    if (!car) {
+      return res.status(404).send({
+        status: 404,
+        message: 'The ad is no longer available',
+      });
+    }
+    const deleteACarAd = CarModel.deleteCar(car);
+    if (deleteACarAd.length < 1) {
+      return res.status(500).send({
+        status: 500,
+        message: 'Ad not deleted, please retry',
+      });
+    }
+
+    return res.status(200).send({
+      status: 200,
+      message: 'Ad successfully deleted',
+    });
+  },
 };
 
 export default Car;

--- a/server/models/CarModel.js
+++ b/server/models/CarModel.js
@@ -128,6 +128,16 @@ class Car {
     return this.cars.filter(car => parseInt(car.price, 10)
       >= parseInt(min, 10) && parseInt(car.price, 10) <= parseInt(max, 10));
   }
+
+  /**
+   * @description - delete a car
+   * @param {Object} car
+   * @returns {Array} of item deleted or empty array if none is deleted
+   */
+  deleteCar(car) {
+    const addIndex = this.cars.indexOf(car);
+    return this.cars.splice(addIndex, 1);
+  }
 }
 
 export default new Car();

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -68,6 +68,9 @@ router.get('/cars/status/available', Car.getAllUnsoldCars);
 
 // get all cars
 router.get('/car', adminAuth, Car.getAll);
+
+// admin delete an ad
+router.delete('/car/:id', adminAuth, Car.deleteAd);
 router.get('/', (req, res) => res.status(200).send('Hello world'));
 
 export default router;

--- a/server/test/integration/CarController.spec.js
+++ b/server/test/integration/CarController.spec.js
@@ -426,4 +426,56 @@ describe('Cars', () => {
       });
     });
   });
+
+  // admin can delete any posted ad
+  describe('Admin can delete a posted ad', () => {
+    it('should delete a posted ad', (done) => {
+      const user = usersData[0];
+      user.isAdmin = true;
+      carsArray();
+      const token = generateToken(user.id, user.isAdmin);
+      chai.request(server).delete(`/api/v1/car/${carsData[0].id}`).set('x-auth', token)
+        .end((err, res) => {
+          expect(res.status).to.eq(200);
+          expect(res.body.message).to.eq('Ad successfully deleted');
+          done();
+        });
+    });
+    it('should return error 401 if user is not admin or not logged in', (done) => {
+      carsArray();
+      chai.request(server).delete(`/api/v1/car/${carsData[0].id}`)
+        .end((err, res) => {
+          expect(res.status).to.eq(401);
+          expect(res.body.message).to.eq('No authorization token provided');
+          done();
+        });
+    });
+    it('should return error 404 if wrong ad id is given', (done) => {
+      const user = usersData[0];
+      user.isAdmin = true;
+      carsArray();
+      const token = generateToken(user.id, user.isAdmin);
+      const id = carsData[0].id + 1;
+      chai.request(server).delete(`/api/v1/car/${id}`).set('x-auth', token)
+        .end((err, res) => {
+          expect(res.status).to.eq(404);
+          expect(res.body.message).to.eq('The ad is no longer available');
+          done();
+        });
+    });
+    it('should return error 404 if ad is not available', (done) => {
+      const user = usersData[0];
+      user.isAdmin = true;
+      const token = generateToken(user.id, user.isAdmin);
+      const { id } = carsData[0];
+      Cars.cars = [];
+      chai.request(server).delete(`/api/v1/car/${id}`).set('x-auth', token)
+        .end((err, res) => {
+          console.log(res);
+          expect(res.status).to.eq(404);
+          expect(res.body.message).to.eq('The ad is no longer available');
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

- Add feature to delete an ad by admin 

#### Description of Task to be completed?

- Have delete ads endpoint functional `/api/v1/car/:id`

#### How should this be manually tested?

- On Postman, create a user account as admin

- [ ] Sign into your account using the email and password and get the generated token `x-auth`

- [ ] set the Content-Type to Application/Json

- [ ] On the params tab, set key to `x-auth` and value to `the copied token`

- [ ] send a `delete` request to this url `/api/v1/car/:id` with a valid ad id

#### What are the relevant pivotal tracker stories?
[#166105280](https://www.pivotaltracker.com/story/show/166105280)
