### PR TITLE
 #166105300: User flag an ad

### DIFF
--- a/server/controllers/FlagController.js
+++ b/server/controllers/FlagController.js
@@ -1,0 +1,35 @@
+import CarModel from '../models/CarModel';
+import FlagModel from '../models/FlagModel';
+
+const Flag = {
+  createFlag(req, res) {
+    if (!req.body.carId || !req.body.reason) {
+      return res.status(400).send({
+        status: 400,
+        message: 'Ensure to indicate the ad id and reason for the report',
+      });
+    }
+
+    const car = CarModel.findSingle(req.body.carId);
+    if (!car || car.status.toLowerCase() !== 'available') {
+      return res.status(404).send({
+        status: 404,
+        message: 'The ad is not longer active. Thank you.',
+      });
+    }
+    req.body.reportedBy = req.userId;
+    // state the report severity level
+    if (req.body.reason.toLowerCase() === 'fake' || req.body.reason.toLowerCase() === 'stolen' || req.body.reason === 'suspicious') {
+      req.body.severity = 'extreme';
+    }
+    // send the report
+    const newFlag = FlagModel.createFlag(req.body);
+
+    return res.status(200).send({
+      status: 200,
+      data: newFlag,
+    });
+  },
+};
+
+export default Flag;

--- a/server/models/FlagModel.js
+++ b/server/models/FlagModel.js
@@ -1,0 +1,22 @@
+class Flag {
+  constructor() {
+    this.flags = [];
+  }
+
+  createFlag(data) {
+    const newFlag = {
+      id: Date.now(),
+      carId: data.carId,
+      createdOn: new Date().toLocaleString(),
+      reason: data.reason || '',
+      description: data.description || '',
+      reportedBy: data.reportedBy || '',
+      status: 'pending',
+      severity: data.severity || 'minor',
+    };
+    this.flags.push(newFlag);
+    return newFlag;
+  }
+}
+
+export default new Flag();

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,6 +5,7 @@ import Car from '../controllers/CarController';
 import auth from '../middleware/auth';
 import adminAuth from '../middleware/admin';
 import Order from '../controllers/OrderController';
+import Flag from '../controllers/FlagController';
 
 const storage = multer.diskStorage({
   filename: (req, file, cb) => {
@@ -79,6 +80,8 @@ router.post('/order', auth, Order.create);
 // seller update offer price
 router.patch('/order', auth, Order.updatePrice);
 
+// flag an ad
+router.post('/flag', auth, Flag.createFlag);
 router.get('/', (req, res) => res.status(200).send('Hello world'));
 
 export default router;

--- a/server/test/integration/FlagController.spec.js
+++ b/server/test/integration/FlagController.spec.js
@@ -1,0 +1,150 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import carsData from '../carsData';
+import server from '../../index';
+import CarModel from '../../models/CarModel';
+import UserModel from '../../models/UserModel';
+import generateToken from '../../lib/generateToken';
+import usersData from '../usersData';
+
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+describe('Flags controller', () => {
+  afterEach(() => {
+    CarModel.cars = [];
+    UserModel.users = [];
+  });
+  describe('Create a flag', () => {
+    it('should create a flag on an ad', (done) => {
+      carsData[0].owner = usersData[1].id;
+      CarModel.cars = carsData;
+      UserModel.users = usersData;
+
+      const user = usersData[0];
+      user.isAdmin = false;
+      const token = generateToken(user.id, user.isAdmin);
+      const data = {
+        carId: carsData[0].id,
+        reason: 'Wrong Description',
+        description: 'Weird description of the car by the owner',
+        reportedBy: user.id,
+      };
+      chai.request(server).post('/api/v1/flag').set('x-auth', token).send(data)
+        .end((err, res) => {
+          expect(res.status).to.eq(200);
+          expect(res.body.data).to.have.property('id');
+          expect(res.body.data).to.have.property('carId').eq(data.carId);
+          expect(res.body.data.reason).to.eq(data.reason);
+          done();
+        });
+    });
+    it('should return error 400 if reason is not stated', (done) => {
+      carsData[0].owner = usersData[1].id;
+      CarModel.cars = carsData;
+      UserModel.users = usersData;
+
+      const user = usersData[0];
+      user.isAdmin = false;
+      const token = generateToken(user.id, user.isAdmin);
+      const data = {
+        carId: carsData[0].id,
+        reason: '',
+        description: 'Weird description of the car by the owner',
+        reportedBy: user.id,
+      };
+      chai.request(server).post('/api/v1/flag').set('x-auth', token).send(data)
+        .end((err, res) => {
+          expect(res.status).to.eq(400);
+          expect(res.body.message).to.eq('Ensure to indicate the ad id and reason for the report');
+          done();
+        });
+    });
+    it('should return error 400 if ad id is not stateds', (done) => {
+      carsData[0].owner = usersData[1].id;
+      CarModel.cars = carsData;
+      UserModel.users = usersData;
+
+      const user = usersData[0];
+      user.isAdmin = false;
+      const token = generateToken(user.id, user.isAdmin);
+      const data = {
+        carId: '',
+        reason: 'stolen',
+        description: 'Weird description of the car by the owner',
+        reportedBy: user.id,
+      };
+      chai.request(server).post('/api/v1/flag').set('x-auth', token).send(data)
+        .end((err, res) => {
+          expect(res.status).to.eq(400);
+          expect(res.body.message).to.eq('Ensure to indicate the ad id and reason for the report');
+          done();
+        });
+    });
+    it('should return error 404 if ad is not found', (done) => {
+      carsData[0].owner = usersData[1].id;
+      CarModel.cars = carsData;
+      UserModel.users = usersData;
+
+      const user = usersData[0];
+      user.isAdmin = false;
+      const token = generateToken(user.id, user.isAdmin);
+      const data = {
+        carId: carsData[0] + 1,
+        reason: 'stolen',
+        description: 'Weird description of the car by the owner',
+        reportedBy: user.id,
+      };
+      chai.request(server).post('/api/v1/flag').set('x-auth', token).send(data)
+        .end((err, res) => {
+          expect(res.status).to.eq(404);
+          expect(res.body.message).to.eq('The ad is not longer active. Thank you.');
+          done();
+        });
+    });
+    it('should return error 404 if the status of the ad is not equal available', (done) => {
+      carsData[0].owner = usersData[1].id;
+      CarModel.cars = carsData;
+      UserModel.users = usersData;
+      carsData[1].status = 'sold';
+
+      const user = usersData[0];
+      user.isAdmin = false;
+      const token = generateToken(user.id, user.isAdmin);
+      const data = {
+        carId: carsData[1],
+        reason: 'stolen',
+        description: 'Weird description of the car by the owner',
+        reportedBy: user.id,
+      };
+      chai.request(server).post('/api/v1/flag').set('x-auth', token).send(data)
+        .end((err, res) => {
+          expect(res.status).to.eq(404);
+          expect(res.body.message).to.eq('The ad is not longer active. Thank you.');
+          done();
+        });
+    });
+    it('should create an extreme flag if car is flag as stolen or fake or suspicious', (done) => {
+      carsData[0].owner = usersData[1].id;
+      CarModel.cars = carsData;
+      UserModel.users = usersData;
+
+      const user = usersData[0];
+      user.isAdmin = false;
+      const token = generateToken(user.id, user.isAdmin);
+      const data = {
+        carId: carsData[0].id,
+        reason: 'stolen',
+        description: 'Weird description of the car by the owner',
+        reportedBy: user.id,
+      };
+      chai.request(server).post('/api/v1/flag').set('x-auth', token).send(data)
+        .end((err, res) => {
+          expect(res.status).to.eq(200);
+          expect(res.body.data.severity).to.eq('extreme');
+          done();
+        });
+    });
+  });
+});

--- a/server/test/integration/UserController.spec.js
+++ b/server/test/integration/UserController.spec.js
@@ -29,8 +29,11 @@ describe('User', () => {
       };
       chai.request(server).post(signupUrl).send(userDetails).end((err, res) => {
         expect(res.status).to.eq(201);
-        expect(res.body.data).to.have.property('email').eq(userDetails.email);
-        expect(res.body.data).to.have.property('phone').eq(userDetails.phone);
+        expect(res.body.data.email).to.eq(userDetails.email);
+        expect(res.body.data.phone).to.eq(userDetails.phone);
+        expect(res.body.data.address).to.eq(userDetails.address);
+        expect(res.body.data.account_number).to.eq(userDetails.account_number);
+        expect(res.body.data.bank).to.eq(userDetails.bank);
         done();
       });
     });

--- a/server/test/unit/FlagModel.spec.js
+++ b/server/test/unit/FlagModel.spec.js
@@ -1,0 +1,46 @@
+import chai from 'chai';
+import usersdata from '../usersData';
+import carsdata from '../carsData';
+import FlagModel from '../../models/FlagModel';
+
+const { expect } = chai;
+
+describe('Flag model', () => {
+  describe('Create a flag', () => {
+    it('should create a minor new flag', (done) => {
+      const data = {
+        carId: carsdata[0].id,
+        reason: 'Over price',
+        description: 'The car has been used for more than 10 years. The price is too ridiculous',
+        reportedBy: usersdata[0].id,
+      };
+      const newFlag = FlagModel.createFlag(data);
+      const { flags } = FlagModel;
+      expect(newFlag).to.have.property('id');
+      expect(newFlag).to.have.property('carId').eq(data.carId);
+      expect(newFlag).to.have.property('status').eq('pending');
+      expect(newFlag).to.have.property('reportedBy').eq(data.reportedBy);
+      expect(newFlag).to.have.property('severity').eq('minor');
+      expect(flags.length).to.be.greaterThan(0);
+      done();
+    });
+    it('should create a severe flag', (done) => {
+      const data = {
+        carId: carsdata[1].id,
+        reason: 'Stolen',
+        severity: 'Extreme',
+        description: 'Vehicle seems stolen and reported',
+        reportedBy: usersdata[1].id,
+      };
+      const newFlag = FlagModel.createFlag(data);
+      const { flags } = FlagModel;
+      expect(newFlag).to.have.property('id');
+      expect(newFlag).to.have.property('carId').eq(data.carId);
+      expect(newFlag).to.have.property('status').eq('pending');
+      expect(newFlag).to.have.property('severity').eq(data.severity);
+      expect(newFlag).to.have.property('reportedBy').eq(data.reportedBy);
+      expect(flags.length).to.be.greaterThan(0);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- Allows the user to flag fraudulent ads 

#### Description of Task to be completed?

- Have this endpoint working `/api/v1/flag` working

#### How should this be manually tested?

- On Postman, create an account, copy the generated token `x-auth`, visit the ads page to select an ad to report

- [ ] on the headers tab, set the key to `x-auth` and value to the copied token

- [ ]  set the Content-Type to Application/Json

- [ ] send a post request to the above api endpoint with the following key-values (i) carId => the Ad id (ii) reason => state the title of the flag  and an (iii) optional description.



#### What are the relevant pivotal tracker stories?
[#166105300](https://www.pivotaltracker.com/story/show/166105300)