### PR TITLE
#166451737 Add make user an admin

### DIFF
--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -133,7 +133,20 @@ const User = {
       data: updatedUserDetails,
     });
   },
-
+  makeAdmin(req, res) {
+    const user = UserModel.isUserActive('id', req.params.id);
+    if (!user) {
+      return res.status(412).send({
+        status: 412,
+        message: 'User not found or inactive',
+      });
+    }
+    const newAdmin = UserModel.makeUserAdmin(user.id);
+    return res.status(200).send({
+      status: 200,
+      data: newAdmin,
+    });
+  },
 };
 
 export default User;

--- a/server/models/UserModel.js
+++ b/server/models/UserModel.js
@@ -74,6 +74,16 @@ class UserModel {
     }
     return user;
   }
+
+  /**
+   * @param {Number}
+   * @returns {Object}
+   */
+  makeUserAdmin(userId) {
+    const user = this.getUser(userId);
+    user.isAdmin = true;
+    return user;
+  }
 }
 
 export default new UserModel();

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -35,20 +35,11 @@ const router = express.Router();
 // user signup
 router.post('/auth/signup', User.create);
 
-// admin get all users
-router.get('/users', adminAuth, User.getAll);
-
 // user login
 router.post('/auth/signin', User.signIn);
 
-// change password
-router.patch('/user', auth, User.changePassword);
-
 // get cars within a price range
 router.get('/car/price/', Car.getCarsWithinPriceRange);
-
-// create an advert
-router.post('/car', auth, upload.single('img'), Car.create);
 
 // get cars by manufacturer
 router.get('/car/manufacturer/:manufacturer', Car.getCarsByProperty);
@@ -62,11 +53,32 @@ router.get('/car/state/:state', Car.getCarsByProperty);
 // get a single ad
 router.get('/car/:id', Car.getSingleAd);
 
+// get all unsold cars
+router.get('/cars/status/available', Car.getAllUnsoldCars);
+
+/**
+ * Protected routes - users
+ */
+// user make an order
+router.post('/order', auth, Order.create);
+
+// create an advert
+router.post('/car', auth, upload.single('img'), Car.create);
+
+// seller update offer price
+router.patch('/order', auth, Order.updatePrice);
+
+// flag an ad
+router.post('/flag', auth, Flag.createFlag);
 // update ad
 router.patch('/car/:id', auth, Car.updateAdvert);
 
-// get all unsold cars
-router.get('/cars/status/available', Car.getAllUnsoldCars);
+// change password
+router.patch('/user', auth, User.changePassword);
+
+/**
+ * Protected routes - Admin
+ */
 
 // get all cars
 router.get('/car', adminAuth, Car.getAll);
@@ -74,14 +86,12 @@ router.get('/car', adminAuth, Car.getAll);
 // admin delete an ad
 router.delete('/car/:id', adminAuth, Car.deleteAd);
 
-// user make an order
-router.post('/order', auth, Order.create);
+// make user an admin
+router.patch('/user/:id', adminAuth, User.makeAdmin);
 
-// seller update offer price
-router.patch('/order', auth, Order.updatePrice);
+// admin get all users
+router.get('/users', adminAuth, User.getAll);
 
-// flag an ad
-router.post('/flag', auth, Flag.createFlag);
 router.get('/', (req, res) => res.status(200).send('Hello world'));
 
 export default router;

--- a/server/test/unit/UserModel.spec.js
+++ b/server/test/unit/UserModel.spec.js
@@ -60,4 +60,16 @@ describe('User Model', () => {
       expect(user).to.have.property('first_name').eq(usersdata[0].first_name);
     });
   });
+  describe('Make User Admin', () => {
+    it('should make a user an admin', () => {
+      UserModel.users = usersdata;
+      usersdata[0].isAdmin = false;
+
+      const userId = usersdata[0].id;
+      const newAdmin = UserModel.makeUserAdmin(userId);
+      expect(newAdmin).to.be.an('Object');
+      // eslint-disable-next-line no-unused-expressions
+      expect(newAdmin.isAdmin).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

- Makes it possible to make a user an admin

#### Description of Task to be completed?

- Have this patch endpoint working `/api/v1/user/:id`

#### How should this be manually tested?

- On postman, login with your admin details

- login and copy the return token

- set the header ('x-auth', token) and select a user that is not admn

- Send the user details to this endpoint `/api/v1/car/id` 

#### What are the relevant pivotal tracker stories?

[#166451737](https://www.pivotaltracker.com/story/show/166451737)